### PR TITLE
fix(auto-release): 🩹 checkout repo before gh release --verify-tag

### DIFF
--- a/.github/workflows/auto-release.yml
+++ b/.github/workflows/auto-release.yml
@@ -29,7 +29,13 @@ jobs:
     if: startsWith(github.ref, 'refs/tags/')
 
     steps:
-      - name: 🔎 Check whether release already exists
+      - name: � Checkout repository (needed for --verify-tag)
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+        with:
+          fetch-depth: 0
+          persist-credentials: false
+
+      - name: �🔎 Check whether release already exists
         id: existing-release
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
## Problem

The reusable `auto-release.yml` workflow runs:

```bash
gh release create "${GITHUB_REF_NAME}" --title "${GITHUB_REF_NAME}" --generate-notes --verify-tag
```

…without first checking out the repository. `gh` then can't find a local git repo to verify the tag against and fails with:

```
failed to run git: fatal: not a git repository (or any of the parent directories): .git
##[error]Process completed with exit code 1.
```

Caught when releasing [terraform-azuredevops-naming v11.0.0](https://github.com/DownAtTheBottomOfTheMoleHole/terraform-azuredevops-naming/actions/runs/25265646719).

## Fix

Add an `actions/checkout` step (pinned to v6 SHA, full history) before the existing-release lookup so `gh release create --verify-tag` has a working tree to inspect.

## Notes

- No behavior change for callers — still triggered on tag push, still idempotent (skips if release exists).
- `persist-credentials: false` because we use `GITHUB_TOKEN` directly in the env.
